### PR TITLE
disable camera just from config ini

### DIFF
--- a/src/modules/UI/module_ui_camera.py
+++ b/src/modules/UI/module_ui_camera.py
@@ -2,21 +2,24 @@ import cv2  # OpenCV to handle frame format conversion
 import numpy as np
 import pygame
 import threading
-from picamera2 import Picamera2
+
 
 class CameraModule:
-    def __init__(self, width, height):
-        self.picam2 = Picamera2()
-        self.camera_config = self.picam2.create_preview_configuration(main={'size': (width, height), 'format': 'RGB888'})
-        self.picam2.configure(self.camera_config)
-        
-        self.frame = None
-        self.running = True
+    def __init__(self, width, height, use_camera_module):
+        self.use_camera_module = use_camera_module
+        if self.use_camera_module:
+            from picamera2 import Picamera2
+            self.picam2 = Picamera2()
+            self.camera_config = self.picam2.create_preview_configuration(main={'size': (width, height), 'format': 'RGB888'})
+            self.picam2.configure(self.camera_config)
+            
+            self.frame = None
+            self.running = True
 
-        # Start the camera thread
-        self.thread = threading.Thread(target=self.capture_frames, daemon=True)
-        self.thread.start()
-        self.picam2.start()
+            # Start the camera thread
+            self.thread = threading.Thread(target=self.capture_frames, daemon=True)
+            self.thread.start()
+            self.picam2.start()
 
     def update_size(self, width, height):
         self.stop()  # Stop the current camera

--- a/src/modules/module_ui.py
+++ b/src/modules/module_ui.py
@@ -11,7 +11,7 @@ import cv2
 import os
 import sounddevice as sd
 from module_config import load_config
-#from UI.module_ui_camera import CameraModule
+from UI.module_ui_camera import CameraModule
 from UI.module_ui_spectrum import SineWaveVisualizer
 from UI.module_ui_buttons import Button
 from UI.module_ui_fake_terminal import ConsoleAnimation
@@ -244,8 +244,7 @@ class UIManager(threading.Thread):
  
         self.camera_box = self.layouts[5]
         if use_camera_module:
-            pass  # temporarily bypass for debug
-            # self.camera_module = CameraModule(self.camera_box.original_width, self.camera_box.original_height)
+            self.camera_module = CameraModule(self.camera_box.original_width, self.camera_box.original_height, self.use_camera_module)
         else:
             self.camera_module = None
         self.change_camera_resolution = False


### PR DESCRIPTION
this way you can disable the camera from config.ini, the pycamera2 is required for hailo and opencv alone is not working well in the latest os so this is still the best way to use the camera.

it's now just an on / off toggle, no need to comment out lines.. ill work on a new animation for that box when the camera is disabled