### PR TITLE
Fix for the 90 and 270 rotation using the new layout logic

### DIFF
--- a/src/modules/UI/ui_layout.json
+++ b/src/modules/UI/ui_layout.json
@@ -61,7 +61,7 @@
       "x": 0.50,
       "y": 0.90,
       "width": 0.50,
-      "height": 0.10,
+      "height": 0.05,
       "expandable": false
     }
   ],

--- a/src/modules/UI/ui_layout.json
+++ b/src/modules/UI/ui_layout.json
@@ -61,7 +61,7 @@
       "x": 0.50,
       "y": 0.90,
       "width": 0.50,
-      "height": 0.05,
+      "height": 0.10,
       "expandable": false
     }
   ],


### PR DESCRIPTION
Fix for the 90 and 270 rotation using the new layout logic

addressing : the expanded box were not expanding in the right direction and the console was showing in the middle of the layout.