### PR TITLE
Custom PWM value

### DIFF
--- a/src/app-servotester.py
+++ b/src/app-servotester.py
@@ -112,8 +112,84 @@ def auto_calibrate_servo(channel, is_center_servo=False):
     Automatically calibrates a servo to find min, max, and neutral PWM values.
     For a center servo, it calculates additional height values.
     """
-    # [The entire original auto_calibrate_servo function remains unchanged]
-    print("Auto-calibration is in internal testing. Use with caution!")
+    print(f"Starting auto-calibration for servo on channel {channel}...")
+
+    # Find minimum PWM value using a curved approach
+    print("Finding minimum PWM value...")
+    step = 150  # Initial large step
+    pwm_value = MAX_PULSE  # Start at the high end
+    min_pulse = None
+    while step >= 1:
+        print(f"Testing PWM: {pwm_value}")
+        set_servo_pulse(channel, pwm_value)
+        time.sleep(0.5)
+        user_input = input("Did the servo start moving? (y/n): ").strip().lower()
+        if user_input == "y":
+            min_pulse = pwm_value
+            pwm_value -= step
+        else:
+            pwm_value -= step
+        step //= 2
+
+    if min_pulse is None:
+        print("Failed to find minimum PWM value.")
+        return
+    print(f"Servo starts moving at PWM: {min_pulse}")
+
+    # Find maximum PWM value
+    print("Finding maximum PWM value...")
+    step = 50
+    pwm_value = min_pulse  # Start from the found minimum value
+    max_pulse = None
+    while step >= 1:
+        print(f"Testing PWM: {pwm_value}")
+        set_servo_pulse(channel, pwm_value)
+        time.sleep(0.5)
+        user_input = input("Did the servo stop moving? (y/n): ").strip().lower()
+        if user_input == "n":
+            max_pulse = pwm_value
+            pwm_value += step
+        else:
+            max_pulse = pwm_value - step
+            pwm_value -= step
+        step //= 2
+
+    if max_pulse is None:
+        print("Failed to find maximum PWM value.")
+        return
+    print(f"Servo stops moving at PWM: {max_pulse}")
+
+    # Calculate neutral position
+    neutral_pulse = (min_pulse + max_pulse) // 2
+    print(f"Setting servo to neutral position: {neutral_pulse}")
+    set_servo_pulse(channel, neutral_pulse)
+
+    # Output port/starboard values if not a center servo
+    if not is_center_servo:
+        neutral_port = neutral_pulse
+        neutral_starboard = neutral_pulse
+        forward_port = int(neutral_pulse + 0.1 * (max_pulse - neutral_pulse))
+        back_starboard = int(neutral_pulse + 0.1 * (neutral_pulse - min_pulse))
+        forward_starboard = int(neutral_pulse - 0.1 * (neutral_pulse - min_pulse))
+        back_port = int(neutral_pulse - 0.1 * (max_pulse - neutral_pulse))
+
+        print(f"Calibration complete for servo {channel}:")
+        print(f"  Back Port: {back_port}")
+        print(f"  Neutral Port: {neutral_port}")
+        print(f"  Forward Port: {forward_port}")
+        print(f"  Back Starboard: {back_starboard}")
+        print(f"  Neutral Starboard: {neutral_starboard}")
+        print(f"  Forward Starboard: {forward_starboard}")
+
+    else:  # Additional calculations for center servo
+        down_height = abs((min_pulse - max_pulse) // 2)
+        up_height = min_pulse
+        neutral_height = (down_height + up_height) // 2
+
+        print(f"Calibration complete for center servo {channel}:")
+        print(f"  Up Height: {up_height}")
+        print(f"  Neutral Height: {neutral_height}")
+        print(f"  Down Height: {down_height}")
 
 print("Servo Control Menu (Pulse Width)")
 

--- a/src/app-servotester.py
+++ b/src/app-servotester.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import time
 import Adafruit_PCA9685
+from modules.module_config import load_config
 
 try:
     pwm = Adafruit_PCA9685.PCA9685(busnum=1)
@@ -8,19 +9,75 @@ except Exception as e:
     print(f"Error initializing PCA9685: {e}")
     exit()
 
-pwm.set_pwm_freq(60)
+CONFIG = load_config()
+PWM_FREQUENCY = CONFIG['SERVO']['PWM_FREQUENCY']
+
+pwm.set_pwm_freq(PWM_FREQUENCY)
 
 print("Auto calibrate is in internal testing DO NOT USE / risk it unless you know what your doing!!!!")
 
 MIN_PULSE = 0  # Calibrate these values
 MAX_PULSE = 600  # Calibrate these values
 
-def set_servo_pulse(channel, pulse):
+# Track last known pulse width for each channel
+LAST_PULSE_WIDTH = {
+    0: 128,   # Default for channel 0
+    1: 350,   # Default for channel 1
+    2: 350,   # Default for channel 2
+    15: 350   # Default for channel 15
+}
+
+# Global ease value (0.0 to 1.0)
+# 0.0 means instant movement, 1.0 means very smooth, gradual movement
+EASE_VALUE = 1
+# Global speed value (0.0 to 1.0)
+# 0.0 means slowest movement, 1.0 means fastest movement
+SPEED_VALUE = 1
+
+def ease_movement(start_pulse, end_pulse, ease=EASE_VALUE, speed=SPEED_VALUE):
+    ease = max(0.0, min(1.0, ease))
+    speed = max(0.0, min(1.0, speed))
+    base_steps = 200
+    steps = int(base_steps * ease * ((1 - speed) ** 2) + 1)
+    
+    movement_steps = []
+    for i in range(steps + 1):
+        t = i / steps
+        smooth_t = 3 * (t ** 2) - 2 * (t ** 3)
+        interpolated_pulse = int(start_pulse + smooth_t * (end_pulse - start_pulse))
+        movement_steps.append(interpolated_pulse)
+    
+    return movement_steps
+
+def set_servo_pulse(channel, pulse, ease=EASE_VALUE, speed=SPEED_VALUE):
     if MIN_PULSE <= pulse <= MAX_PULSE:
-        pwm.set_pwm(channel, 0, pulse)
-        print(f"Set servo on channel {channel} to pulse {pulse}")
+        # Get the last known pulse width for this channel
+        start_pulse = LAST_PULSE_WIDTH.get(channel, 128)
+        
+        # If ease is 0, move instantly
+        if ease == 0:
+            pwm.set_pwm(channel, 0, pulse)
+            print(f"Set servo on channel {channel} to pulse {pulse}")
+            LAST_PULSE_WIDTH[channel] = pulse
+        else:
+            # Create smooth movement
+            movement_steps = ease_movement(start_pulse, pulse, ease, speed)
+            
+            # More exponential delay calculation
+            base_delay = 0.05  # Increased base delay
+            min_delay = 0.001  # Minimum delay to prevent infinite loops
+            delay = max(min_delay, base_delay * ((1 - speed) ** 3))
+            
+            for step in movement_steps:
+                pwm.set_pwm(channel, 0, step)
+                time.sleep(delay)  # Delay between steps
+            
+            print(f"Smoothly moved servo on channel {channel} to pulse {pulse}")
+            LAST_PULSE_WIDTH[channel] = pulse
     else:
         print(f"Pulse out of range ({MIN_PULSE}-{MAX_PULSE}).")
+
+
 
 def set_all_servos_preset():
     set_servo_pulse(0, 128)  # Example preset pulse for servo 0
@@ -28,98 +85,35 @@ def set_all_servos_preset():
     set_servo_pulse(2, 350)  # Example preset pulse for servo 2
     print("All servos set to preset pulse widths.")
 
+
+
 def set_single_servo(channel):
     while True:
         try:
             pulse = int(input(f"Enter pulse width for servo {channel} ({MIN_PULSE}-{MAX_PULSE}): "))
-            set_servo_pulse(channel, pulse)
+            # Optional: Let user specify ease, otherwise use global EASE_VALUE
+            #ease_input = input(f"Enter ease value (0.0-1.0, default {EASE_VALUE}): ").strip()
+            #ease = float(ease_input) if ease_input else EASE_VALUE
+            ease = EASE_VALUE
+            
+            # Optional: Let user specify speed, otherwise use global SPEED_VALUE
+            #speed_input = input(f"Enter speed value (0.0-1.0, default {SPEED_VALUE}): ").strip()
+            #speed = float(speed_input) if speed_input else SPEED_VALUE
+            speed = SPEED_VALUE
+            
+            set_servo_pulse(channel, pulse, ease, speed)
             break  # Exit the loop after a valid pulse is entered
         except ValueError:
             print("Invalid input. Please enter a number.")
 
+# Rest of the code remains the same as in the original script (auto_calibrate_servo function and menu loop)
 def auto_calibrate_servo(channel, is_center_servo=False):
     """
     Automatically calibrates a servo to find min, max, and neutral PWM values.
     For a center servo, it calculates additional height values.
     """
-    print(f"Starting auto-calibration for servo on channel {channel}...")
-
-    # Find minimum PWM value using a curved approach
-    print("Finding minimum PWM value...")
-    step = 150  # Initial large step
-    pwm_value = MAX_PULSE  # Start at the high end
-    min_pulse = None
-    while step >= 1:
-        print(f"Testing PWM: {pwm_value}")
-        set_servo_pulse(channel, pwm_value)
-        time.sleep(0.5)
-        user_input = input("Did the servo start moving? (y/n): ").strip().lower()
-        if user_input == "y":
-            min_pulse = pwm_value
-            pwm_value -= step
-        else:
-            pwm_value -= step
-        step //= 2
-
-    if min_pulse is None:
-        print("Failed to find minimum PWM value.")
-        return
-    print(f"Servo starts moving at PWM: {min_pulse}")
-
-    # Find maximum PWM value
-    print("Finding maximum PWM value...")
-    step = 50
-    pwm_value = min_pulse  # Start from the found minimum value
-    max_pulse = None
-    while step >= 1:
-        print(f"Testing PWM: {pwm_value}")
-        set_servo_pulse(channel, pwm_value)
-        time.sleep(0.5)
-        user_input = input("Did the servo stop moving? (y/n): ").strip().lower()
-        if user_input == "n":
-            max_pulse = pwm_value
-            pwm_value += step
-        else:
-            max_pulse = pwm_value - step
-            pwm_value -= step
-        step //= 2
-
-    if max_pulse is None:
-        print("Failed to find maximum PWM value.")
-        return
-    print(f"Servo stops moving at PWM: {max_pulse}")
-
-    # Calculate neutral position
-    neutral_pulse = (min_pulse + max_pulse) // 2
-    print(f"Setting servo to neutral position: {neutral_pulse}")
-    set_servo_pulse(channel, neutral_pulse)
-
-    # Output port/starboard values if not a center servo
-    if not is_center_servo:
-        neutral_port = neutral_pulse
-        neutral_starboard = neutral_pulse
-        forward_port = int(neutral_pulse + 0.1 * (max_pulse - neutral_pulse))
-        back_starboard = int(neutral_pulse + 0.1 * (neutral_pulse - min_pulse))
-        forward_starboard = int(neutral_pulse - 0.1 * (neutral_pulse - min_pulse))
-        back_port = int(neutral_pulse - 0.1 * (max_pulse - neutral_pulse))
-
-        print(f"Calibration complete for servo {channel}:")
-        print(f"  Back Port: {back_port}")
-        print(f"  Neutral Port: {neutral_port}")
-        print(f"  Forward Port: {forward_port}")
-        print(f"  Back Starboard: {back_starboard}")
-        print(f"  Neutral Starboard: {neutral_starboard}")
-        print(f"  Forward Starboard: {forward_starboard}")
-
-    else:  # Additional calculations for center servo
-        down_height = abs((min_pulse - max_pulse) // 2)
-        up_height = min_pulse
-        neutral_height = (down_height + up_height) // 2
-
-        print(f"Calibration complete for center servo {channel}:")
-        print(f"  Up Height: {up_height}")
-        print(f"  Neutral Height: {neutral_height}")
-        print(f"  Down Height: {down_height}")
+    # [The entire original auto_calibrate_servo function remains unchanged]
+    print("Auto-calibration is in internal testing. Use with caution!")
 
 print("Servo Control Menu (Pulse Width)")
 
@@ -158,7 +152,7 @@ while True:
                 print("Calibration aborted. Please ensure all safety measures are in place before retrying.")
         except ValueError:
             print("Exiting...")
-    elif choice == '6':
+    elif choice == '7':
         print("Exiting...")
         break
     else:

--- a/src/config.ini.template
+++ b/src/config.ini.template
@@ -191,6 +191,8 @@ channel_id = 811470553139249186
 # ID of the Discord channel for communication (TARS-AI = 1311295891512098920)
 
 [SERVO]
+#!!!IMPORTANT!!! if you are building a new project, use 50, if you are updating from an early build, use 60.
+PWM_FREQUENCY = 50
 #Enable or disable movement via voice control
 voicemovement = False
 # Port for the main servo
@@ -214,6 +216,9 @@ neutralHeight = 168
 # Lower limit for the center servo (CAUTION: Setting too high may cause damage)
 downHeight = 250
 
+# !!!IMPORTANT!!! 
+# With a 60 PWM frequency the Forward and Back values are normally +50 for forward and -50 for back from the neutral value.
+# With a 50 PWM frequency the Forward and Back values are normally +60 for forward and -60 for back from the neutral value.
 # Forward position for the port drive servo
 forwardPort = 400
 # Neutral position for the port drive servo
@@ -223,6 +228,9 @@ backPort = 300
 # Fine-tuning offset for the port drive servo
 perfectportoffset = 0
 
+# !!!IMPORTANT!!! 
+# With a 60 PWM frequency the Forward and Back values are normally -50 for forward and +50 for back from the neutral value.
+# With a 50 PWM frequency the Forward and Back values are normally -60 for forward and +60 for back from the neutral value.
 # Forward position for the starboard drive servo
 forwardStarboard = 300
 # Neutral position for the starboard drive servo
@@ -231,6 +239,36 @@ neutralStarboard = 350
 backStarboard = 400
 # Fine-tuning offset for the starboard drive servo
 perfectStaroffset = 0
+
+
+#AT 60 PWM frequency MIN and MAX represents a 90 degree rotation from the middle. These are reference values
+#SERVO TYPE mg90s
+#min = 180
+#middle = 370
+#max = 580
+#SERVO TYPE LKY2
+#min = 170
+#middle = 370
+#max = 570
+#SERVO TYPE LDX-227
+#min = 220
+#middle = 370
+#max = 520
+
+#AT 50 PWM Frequency, MIN and MAX values represent a 90 rotation from the middle.
+#SERVO TYPE mg90s
+#min = 140
+#middle = 300
+#max = 490
+#SERVO TYPE LKY62
+#min = 130
+#middle = 300
+#max = 480
+#SERVO TYPE LDX-227
+#min = 170
+#middle = 300
+#max = 430
+
 
 
 [BATTERY]

--- a/src/modules/module_config.py
+++ b/src/modules/module_config.py
@@ -223,6 +223,7 @@ def load_config():
             "enabled": config['DISCORD']['enabled'],
         },
         "SERVO": {
+            "PWM_FREQUENCY": int(config['SERVO']['PWM_FREQUENCY']),
             "portMain": config['SERVO']['portMain'],
             "portForarm": config['SERVO']['portForarm'],
             "portHand": config['SERVO']['portHand'],


### PR DESCRIPTION
I made it so the config.ini holds the custom PWM value, by default it is set to 50 but if you built your project using the original value (60) then keep 60. 

the difference in the PWM is the servo positions, they will not be the same if you change from one PWM to another.
a frequency of 60 PWM will require a + 50/ -50 value from the middle position and a 50 PWM value requires a (+60 / -60) to get the same results... the middle (or neutral) position value is also different so it requires resetting the servo positions if going from one to another.

This changes allows for 2 things, the use of digital servos, which are much more precises as some will burnout with a value other than 50, and it also avoid the smaller servos for jumping around uncontrollably which leads to them failing. 50hz is the normal value for hobby servo of different types used in this project.


I have also added an EASE in / out function and a SPEED value in the servo tester application. These values are set to maximum by default.