### PR TITLE
Fixed JSON output format example in movement LLM call prompt

### DIFF
--- a/src/modules/module_engine.py
+++ b/src/modules/module_engine.py
@@ -142,10 +142,8 @@ def movement_llmcall(user_input):
     2. Extract the number of steps or the angle of turn if applicable, where 180 degrees equals 2 steps (90 degrees = 1 step).
     3. Respond with a structured JSON output in the exact format:
     {{
-        "movement": "{{
-            "movement": "<MOVEMENT>",
-            "times": <TIMES>
-        }}
+        "movement": "<MOVEMENT>",
+        "times": <TIMES>
     }}
 
     Rules:


### PR DESCRIPTION
The example provided to the LLM in the prompt to determine the movement to send to the cervomotors was: {{
    "movement": {{
        "movement": "<MOVEMENT>",
        "times": <TIMES>
    }}
}}

Testing this raises a JSON interpretation error
To be interpreted properly it must be:
{{
        "movement": "<MOVEMENT>",
        "times": <TIMES>
}}