### PR TITLE
Move WiFi icon from Eyes HUD to bottom toolbar

### DIFF
--- a/src/modules/UI/apps/module_app_eyes.py
+++ b/src/modules/UI/apps/module_app_eyes.py
@@ -1,26 +1,14 @@
 """
 Module: Eyes App
 Author: Latisha Besariani Hendra
-Description: Pygame app that renders RoboEyes with a WiFi signal HUD overlay.
+Description: Pygame app that renders RoboEyes.
              Follows the TARS-AI app framework (init/reset/update/render/cleanup).
 """
 
-import os
 import time
 import pygame
 
 from modules.module_eyes import RoboEyes, Mood
-
-# WiFi status helper
-try:
-    from modules.module_wifi import get_wifi_status
-    HAS_WIFI = True
-except Exception:
-    HAS_WIFI = False
-    def get_wifi_status():
-        return {"mode": "disconnected", "ssid": None, "ip": None, "signal": 0}
-
-_ASSET_DIR = os.path.dirname(os.path.abspath(__file__))
 
 _mood_request = None
 
@@ -29,18 +17,7 @@ def set_mood_request(mood):
     _mood_request = mood
 
 
-def _load_icon(name: str, size: int = 32) -> pygame.Surface | None:
-    path = os.path.join(_ASSET_DIR, name)
-    try:
-        img = pygame.image.load(path).convert_alpha()
-        return pygame.transform.smoothscale(img, (size, size))
-    except Exception:
-        return None
-
-
 class EyesApp:
-    POLL_INTERVAL = 5.0
-
     def __init__(self, screen, width, height):
         self.screen = screen
         self.width = width
@@ -49,36 +26,16 @@ class EyesApp:
         self.eyes = RoboEyes(width, height)
         self.eyes.set_mood(Mood.NEUTRAL)
 
-        self._last_poll = 0.0
-        self._wifi_signal = 0
-        self._wifi_mode = "disconnected"
-
-        self._icon_blue   = _load_icon("wifi-blue.png")
-        self._icon_yellow = _load_icon("wifi-yellow.png")
-        self._icon_gray   = _load_icon("wifi-gray.png")
-
         self._prev_time = time.time()
-        self._poll_status()
 
     def reset(self):
         self.eyes.set_mood(Mood.NEUTRAL)
         self._prev_time = time.time()
-        self._poll_status()
-
-    def _poll_status(self):
-        self._last_poll = time.time()
-        if HAS_WIFI:
-            status = get_wifi_status()
-            self._wifi_signal = status.get("signal", 0)
-            self._wifi_mode   = status.get("mode", "disconnected")
 
     def update(self):
         now = time.time()
         dt = now - self._prev_time
         self._prev_time = now
-
-        if now - self._last_poll >= self.POLL_INTERVAL:
-            self._poll_status()
 
         global _mood_request
         if _mood_request is not None:
@@ -89,19 +46,6 @@ class EyesApp:
     def render(self):
         self.screen.fill((13, 17, 23))
         self.eyes.draw(self.screen)
-        self._draw_hud(self.screen)
-
-    def _wifi_icon(self):
-        if self._wifi_mode == "hotspot":
-            return self._icon_yellow
-        if self._wifi_mode == "client":
-            return self._icon_blue
-        return self._icon_gray
-
-    def _draw_hud(self, surface):
-        icon = self._wifi_icon()
-        if icon:
-            surface.blit(icon, (10, 10))
 
     def cleanup(self):
         pass

--- a/src/modules/UI/module_ui_terminal.py
+++ b/src/modules/UI/module_ui_terminal.py
@@ -25,6 +25,14 @@ from typing import List, Tuple, Callable, Optional
 
 from modules.module_config import load_config
 
+try:
+    from modules.module_wifi import get_wifi_status as _get_wifi_status
+    _HAS_WIFI = True
+except Exception:
+    _HAS_WIFI = False
+    def _get_wifi_status():
+        return {"mode": "disconnected", "ssid": None, "ip": None, "signal": 0}
+
 CONFIG = load_config()
 
 class TerminalSystem:
@@ -156,6 +164,26 @@ class TerminalSystem:
         self.app_list = []
         self.app_menu_rect = None
         self.back_button_rect = None
+
+
+        # WiFi status state
+        self._wifi_mode = "disconnected"
+        self._wifi_signal = 0
+        self._last_wifi_poll = 0.0
+        self._wifi_poll_interval = 5.0
+        _icon_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "apps")
+        self._wifi_icon_blue   = self._load_wifi_icon(os.path.join(_icon_dir, "wifi-blue.png"))
+        self._wifi_icon_yellow = self._load_wifi_icon(os.path.join(_icon_dir, "wifi-yellow.png"))
+        self._wifi_icon_gray   = self._load_wifi_icon(os.path.join(_icon_dir, "wifi-gray.png"))
+        # Initial wifi poll
+        if _HAS_WIFI:
+            try:
+                _s = _get_wifi_status()
+                self._wifi_mode   = _s.get("mode", "disconnected")
+                self._wifi_signal = _s.get("signal", 0)
+            except Exception:
+                pass
+        self._last_wifi_poll = import_time = __import__("time").time()
 
         self.overlay_surface = pygame.Surface((width, height), pygame.SRCALPHA)
 
@@ -496,6 +524,13 @@ class TerminalSystem:
             battery_height = button_height
             right_x -= battery_width
             self._draw_battery_indicator(surface, right_x, y, battery_width, battery_height)
+            right_x -= 8
+
+        if self._wifi_icon_gray is not None:
+            wifi_size = button_height
+            right_x -= 8
+            right_x -= wifi_size
+            self._draw_wifi_icon(surface, right_x, y, wifi_size)
 
     def handle_app_click(self, pos: Tuple[int, int]) -> bool:
         now = pygame.time.get_ticks()
@@ -648,6 +683,16 @@ class TerminalSystem:
                     self.cpu_temp_history.pop(0)
                 self.last_cpu_update_time = current_time
 
+        if _HAS_WIFI:
+            if current_time - self._last_wifi_poll >= self._wifi_poll_interval:
+                try:
+                    status = _get_wifi_status()
+                    self._wifi_mode   = status.get("mode", "disconnected")
+                    self._wifi_signal = status.get("signal", 0)
+                except Exception:
+                    pass
+                self._last_wifi_poll = current_time
+
     def _draw_tech_button(self, surface, rect, label, code, active=False, color_type=None, disabled=False):
         if disabled:
 
@@ -686,6 +731,27 @@ class TerminalSystem:
         text_surface = self.toolbar_font.render(label, True, text_color)
         text_rect = text_surface.get_rect(center=rect.center)
         surface.blit(text_surface, text_rect)
+
+    def _load_wifi_icon(self, path: str):
+        try:
+            img = pygame.image.load(path).convert_alpha()
+            return img
+        except Exception:
+            return None
+
+    def _current_wifi_icon(self):
+        if self._wifi_mode == "hotspot":
+            return self._wifi_icon_yellow
+        if self._wifi_mode == "client":
+            return self._wifi_icon_blue
+        return self._wifi_icon_gray
+
+    def _draw_wifi_icon(self, surface, x, y, size):
+        icon = self._current_wifi_icon()
+        if icon is None:
+            return
+        scaled = pygame.transform.smoothscale(icon, (size, size))
+        surface.blit(scaled, (x, y))
 
     def _draw_battery_indicator(self, surface, x, y, width, height):
         if not self.battery_module:
@@ -1125,6 +1191,14 @@ class TerminalSystem:
             cpu_y = bottom_toolbar_y + 5
             self._draw_cpu_temp_indicator(self.overlay_surface, cpu_x, cpu_y,
                                           cpu_width, cpu_height)
+
+        if self._wifi_icon_gray is not None:
+            wifi_size = self.bottom_toolbar_height - 10
+            wifi_x = self.width - wifi_size - 10
+            if self.cpu_temp_module and self.show_cpu_temp:
+                wifi_x -= (80 + 8)
+            wifi_y = bottom_toolbar_y + 5
+            self._draw_wifi_icon(self.overlay_surface, wifi_x, wifi_y, wifi_size)
 
         if not self.camera_active:
             self._draw_scroll_buttons(self.overlay_surface)


### PR DESCRIPTION
The WiFi status icon was previously overlaid on the Eyes app screen (top-left corner). It is now rendered in the persistent bottom toolbar of the terminal UI, beside the battery indicator, so it stays visible across all views instead of only when the Eyes app is active.

- module_app_eyes: removed WiFi polling, icon loading, and HUD overlay
- module_ui_terminal: added WiFi import, icon loading, status polling, and rendering in both draw_back_button() and the main draw() toolbar