### PR TITLE
feat: Movement Builder tab + eye animation cleanup

### DIFF
--- a/src/modules/module_chatui.py
+++ b/src/modules/module_chatui.py
@@ -11,6 +11,7 @@ import sys
 import shutil
 import threading
 import time
+from pathlib import Path
 import logging
 import json
 import asyncio
@@ -2863,6 +2864,245 @@ def dashboard_prompt():
         })
     return jsonify({"interactions": items
     })
+
+
+# ── Movement Builder ─────────────────────────────────────────────────────────
+
+_SEQUENCES_FILE = Path(__file__).parent.parent / "custom_sequences.json"
+
+
+def _load_sequences():
+    if not _SEQUENCES_FILE.exists():
+        return {}
+    try:
+        return json.loads(_SEQUENCES_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def _save_sequences(data):
+    _SEQUENCES_FILE.write_text(json.dumps(data, indent=2))
+
+
+@flask_app.route('/get_arms_status', methods=['GET'])
+def get_arms_status():
+    import modules.module_servoctl as _sc
+    return jsonify({"arms_present": bool(_sc.ARMS_PRESENT)}), 200
+
+
+@flask_app.route('/play_sequence', methods=['POST'])
+def play_sequence():
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+    steps = request.get_json().get('steps', [])
+    return _execute_steps(steps)
+
+
+@flask_app.route('/save_sequence', methods=['POST'])
+def save_sequence():
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    data = request.get_json()
+    name = data.get('name', '').strip()
+    if not name:
+        return jsonify({"error": "name required"}), 400
+
+    steps = data.get('steps', [])
+    seq_type = data.get('type', 'movement')
+    quick = bool(data.get('quick', False))
+
+    sequences = _load_sequences()
+    sequences[name] = {"type": seq_type, "quick": quick, "steps": steps}
+    _save_sequences(sequences)
+    return jsonify({"success": True, "name": name}), 200
+
+
+@flask_app.route('/get_saved_sequences', methods=['GET'])
+def get_saved_sequences():
+    return jsonify(_load_sequences()), 200
+
+
+@flask_app.route('/delete_saved_sequence', methods=['POST'])
+def delete_saved_sequence():
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    data = request.get_json()
+    name = data.get('name', '').strip()
+    sequences = _load_sequences()
+    if name not in sequences:
+        return jsonify({"error": f"'{name}' not found"}), 404
+
+    del sequences[name]
+    _save_sequences(sequences)
+    return jsonify({"success": True}), 200
+
+
+@flask_app.route('/play_saved_sequence', methods=['POST'])
+def play_saved_sequence():
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    data = request.get_json()
+    name = data.get('name', '').strip()
+    sequences = _load_sequences()
+    if name not in sequences:
+        return jsonify({"error": f"'{name}' not found"}), 404
+
+    entry = sequences[name]
+    steps = entry.get('steps', []) if isinstance(entry, dict) else entry
+    return _execute_steps(steps)
+
+
+def _execute_steps(steps):
+    import modules.module_servoctl as _sc
+    import time as _time
+
+    if _sc.MOVING:
+        return jsonify({"error": "Robot is already moving"}), 409
+
+    _sc.MOVING = True
+    _sc._notify_movement_start()
+    try:
+        for step in steps:
+            if step.get('movement'):
+                name = step['movement']
+                if name in globals():
+                    globals()[name]()
+                elif name == 'reset_positions':
+                    reset_positions()
+            else:
+                lh = step.get('left_height', 50)
+                rh = step.get('right_height', 50)
+                ll = step.get('left_leg', 50)
+                rl = step.get('right_leg', 50)
+                spd = step.get('speed', 0.85)
+                move_legs(lh, rh, ll, rl, spd)
+
+                if _sc.ARMS_PRESENT:
+                    lm = step.get('left_main')
+                    lf = step.get('left_forearm')
+                    lhv = step.get('left_hand')
+                    rm = step.get('right_main')
+                    rf = step.get('right_forearm')
+                    rhv = step.get('right_hand')
+                    if any(v is not None for v in [lm, lf, lhv, rm, rf, rhv]):
+                        move_arm(lm, lf, lhv, rm, rf, rhv, spd)
+
+                hold = step.get('hold_time', 0.0)
+                if hold and hold > 0:
+                    _time.sleep(hold)
+
+        move_legs(50, 50, 50, 50, 0.8)
+        disable_all_servos()
+        return jsonify({"success": True}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        _sc.MOVING = False
+        _sc._notify_movement_end()
+
+
+@flask_app.route('/get_movement_steps/<name>', methods=['GET'])
+def get_movement_steps(name):
+    import modules.module_movements as _mm
+    import inspect
+
+    try:
+        src = inspect.getsource(getattr(_mm, name))
+    except (AttributeError, OSError):
+        return jsonify({"error": f"Movement '{name}' not found"}), 404
+
+    steps = _parse_movement_steps(src)
+    if not steps:
+        return jsonify({"error": f"No move_legs calls found in '{name}'"}), 422
+
+    return jsonify({"name": name, "steps": steps}), 200
+
+
+def _parse_movement_steps(src):
+    import re as _re
+
+    def parse_val(v, default=50):
+        try:
+            return int(round(float(v)))
+        except (ValueError, TypeError):
+            return default
+
+    def extract_steps(lines):
+        result = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            loop_m = _re.search(r"for\s+\w+\s+in\s+range\((\d+)\)\s*:", line)
+            if loop_m:
+                repeat = int(loop_m.group(1))
+                loop_indent = len(line) - len(line.lstrip())
+                body_lines = []
+                i += 1
+                while i < len(lines):
+                    bl = lines[i]
+                    if bl.strip() == "":
+                        i += 1
+                        continue
+                    bl_indent = len(bl) - len(bl.lstrip())
+                    if bl_indent > loop_indent:
+                        body_lines.append(bl)
+                        i += 1
+                    else:
+                        break
+                for _ in range(repeat):
+                    result.extend(extract_steps(body_lines))
+                continue
+
+            ml = _re.search(r"move_legs\(([^)]+)\)", line)
+            if ml:
+                args = [a.strip() for a in ml.group(1).split(",")]
+                if len(args) >= 4:
+                    step = {
+                        "movement": None,
+                        "left_height": parse_val(args[0]),
+                        "right_height": parse_val(args[1]),
+                        "left_leg": parse_val(args[2]),
+                        "right_leg": parse_val(args[3]),
+                        "left_main": None, "left_forearm": None, "left_hand": None,
+                        "right_main": None, "right_forearm": None, "right_hand": None,
+                        "speed": round(float(args[4]), 2) if len(args) > 4 and _re.match(r"[\d.]+", args[4]) else 0.85,
+                        "hold_time": 0.0
+                    }
+                    # check for time.sleep on next 1-2 lines
+                    for j in range(i + 1, min(i + 3, len(lines))):
+                        sl = _re.search(r"time\.sleep\(([^)]+)\)", lines[j])
+                        if sl:
+                            try:
+                                step["hold_time"] = float(sl.group(1))
+                            except ValueError:
+                                pass
+                            break
+                    result.append(step)
+
+            arm_m = _re.search(r"move_arm\(([^)]+)\)", line)
+            if arm_m and result:
+                args = [a.strip() for a in arm_m.group(1).split(",")]
+                def _arm_val(v):
+                    try:
+                        return int(round(float(v)))
+                    except (ValueError, TypeError):
+                        return None
+                if len(args) >= 6:
+                    result[-1]["left_main"] = _arm_val(args[0])
+                    result[-1]["left_forearm"] = _arm_val(args[1])
+                    result[-1]["left_hand"] = _arm_val(args[2])
+                    result[-1]["right_main"] = _arm_val(args[3])
+                    result[-1]["right_forearm"] = _arm_val(args[4])
+                    result[-1]["right_hand"] = _arm_val(args[5])
+
+            i += 1
+        return result
+
+    lines = src.splitlines()
+    return extract_steps(lines)
 
 
 def start_flask_app(port=None):

--- a/src/modules/module_eyes.py
+++ b/src/modules/module_eyes.py
@@ -181,17 +181,6 @@ class RoboEyes:
         self._saccade_timer = 0.0
         self._next_saccade = random.uniform(0.5, 2.0)
 
-        # Animation system
-        self._current_animation = None
-        self._anim_timer = 0.0
-        self._anim_duration = 0.0
-        self._anim_phase = 0.0
-
-        # Legacy animations
-        self._anim_laugh = False
-        self._anim_laugh_timer = 0.0
-        self._anim_confused = False
-        self._anim_confused_timer = 0.0
         self._anim_offset_x = 0.0
         self._anim_offset_y = 0.0
 
@@ -256,64 +245,6 @@ class RoboEyes:
 
     def set_squint(self, intensity: float):
         self._squint_target = max(0.0, min(1.0, intensity))
-
-    # ── Animation Sequences ───────────────────────────────────────────────────
-
-    def is_animating(self) -> bool:
-        return self._current_animation is not None
-
-    def anim_wink(self, eye: str = 'right'):
-        self._current_animation = 'wink'
-        self._anim_timer = 0.0
-        self._anim_duration = 0.3
-        self._blink_left = (eye == 'left')
-        self._blink_right = (eye == 'right')
-
-    def anim_double_take(self):
-        self._current_animation = 'double_take'
-        self._anim_timer = 0.0
-        self._anim_duration = 1.5
-        self._anim_phase = 0
-
-    def anim_eye_roll(self):
-        self._current_animation = 'eye_roll'
-        self._anim_timer = 0.0
-        self._anim_duration = 2.0
-
-    def anim_excited(self):
-        self._current_animation = 'excited'
-        self._anim_timer = 0.0
-        self._anim_duration = 0.8
-
-    def anim_sleepy(self):
-        self._current_animation = 'sleepy'
-        self._anim_timer = 0.0
-        self._anim_duration = 2.0
-
-    def anim_thinking(self):
-        self._current_animation = 'thinking'
-        self._anim_timer = 0.0
-        self._anim_duration = 2.5
-        self._anim_phase = 0
-
-    def anim_blink_fast(self):
-        self._current_animation = 'blink_fast'
-        self._anim_timer = 0.0
-        self._anim_duration = 0.4
-        self._anim_phase = 0
-
-    def anim_squint_suspicious(self):
-        self._current_animation = 'squint_suspicious'
-        self._anim_timer = 0.0
-        self._anim_duration = 1.5
-
-    def anim_laugh(self):
-        self._anim_laugh = True
-        self._anim_laugh_timer = 0.5
-
-    def anim_confused(self):
-        self._anim_confused = True
-        self._anim_confused_timer = 0.5
 
     def get_current_mood(self) -> Tuple[Mood, float]:
         return (self._mood, self._mood_intensity)
@@ -623,7 +554,6 @@ class RoboEyes:
                 self._next_saccade = random.uniform(0.5, 2.0)
 
         if self._touch_reaction is None:
-            self._update_animations(dt)
             self._update_mood(dt)
 
         speed = EMOTION_TRANSITION_SPEEDS.get(self._mood, 6.0)
@@ -667,96 +597,6 @@ class RoboEyes:
             h[0] += h[4] * dt   # horizontal drift
             h[2] *= 0.995       # shrink slowly
         self._heart_particles = [h for h in self._heart_particles if h[3] < 2.5]
-
-    def _update_animations(self, dt: float):
-        if self._current_animation is None:
-            if self._anim_laugh:
-                self._anim_laugh_timer -= dt
-                self._anim_offset_y = math.sin(self._anim_laugh_timer * 50) * 5
-                if self._anim_laugh_timer <= 0:
-                    self._anim_laugh = False
-                    self._anim_offset_y = 0
-            if self._anim_confused:
-                self._anim_confused_timer -= dt
-                self._anim_offset_x = math.sin(self._anim_confused_timer * 50) * 5
-                if self._anim_confused_timer <= 0:
-                    self._anim_confused = False
-                    self._anim_offset_x = 0
-            return
-
-        self._anim_timer += dt
-        progress = min(1.0, self._anim_timer / self._anim_duration)
-
-        if self._current_animation == 'wink':
-            if progress < 0.5:
-                self._is_blinking = True
-                self._blink_phase = progress * 2
-            else:
-                self._is_blinking = False
-
-        elif self._current_animation == 'double_take':
-            if progress < 0.3:
-                self._target_look_x = 0.8
-            elif progress < 0.35:
-                self._target_look_x = 0.0
-            elif progress < 0.6:
-                self._left_open_target = 1.3
-                self._right_open_target = 1.3
-            else:
-                self._left_open_target = 1.0
-                self._right_open_target = 1.0
-
-        elif self._current_animation == 'eye_roll':
-            angle = progress * 3.14159 * 2
-            self._target_look_x = math.sin(angle) * 0.6
-            self._target_look_y = -math.cos(angle) * 0.6 - 0.3
-
-        elif self._current_animation == 'excited':
-            bounce = math.sin(progress * 3.14159 * 4) * 0.3
-            self._anim_offset_y = -abs(bounce) * 10
-            self._left_open_target = 1.3
-            self._right_open_target = 1.3
-
-        elif self._current_animation == 'sleepy':
-            if progress < 0.7:
-                self._left_open_target = 1.0 - progress / 0.7
-                self._right_open_target = 1.0 - progress / 0.7
-            else:
-                self._left_open_target = 1.0
-                self._right_open_target = 1.0
-
-        elif self._current_animation == 'thinking':
-            cycle = int(progress * 3)
-            if cycle == 0:
-                self._target_look_x = -0.4
-                self._target_look_y = -0.6
-            elif cycle == 1:
-                self._target_look_x = 0.4
-                self._target_look_y = -0.6
-            else:
-                self._target_look_x = 0.0
-                self._target_look_y = 0.0
-            self._squint_target = 0.2
-
-        elif self._current_animation == 'blink_fast':
-            blink_cycle = int(progress * 4) % 2
-            if blink_cycle == 0:
-                self._left_open_target = 0.0
-                self._right_open_target = 0.0
-            else:
-                self._left_open_target = 1.0
-                self._right_open_target = 1.0
-
-        elif self._current_animation == 'squint_suspicious':
-            self._squint_target = progress * 0.7
-            self._target_look_x = math.sin(progress * 3.14159) * 0.3
-
-        if progress >= 1.0:
-            self._current_animation = None
-            self._anim_timer = 0.0
-            self._anim_offset_x = 0.0
-            self._anim_offset_y = 0.0
-            self._squint_target = 0.0
 
     def _update_mood(self, dt: float):
         target_top_l = 0.0

--- a/src/www/static/js/main.js
+++ b/src/www/static/js/main.js
@@ -2619,8 +2619,8 @@ window.showToast = function (message, type, duration) {
 
 // ── MOBILE SWIPE NAV ─────────────────────────────────────────────────────────
 (function () {
-  const TAB_IDS = ['chat', 'motion', 'body', 'emotions', 'wifi', 'config', 'dashboard', 'nexus'];
-  const TAB_BTN_IDS = ['chat-tab', 'motion-tab', 'body-tab', 'emotions-tab', 'wifi-tab', 'config-tab', 'dashboard-tab', 'nexus-tab'];
+  const TAB_IDS = ['chat', 'motion', 'body', 'emotions', 'wifi', 'config', 'dashboard', 'nexus', 'builder'];
+  const TAB_BTN_IDS = ['chat-tab', 'motion-tab', 'body-tab', 'emotions-tab', 'wifi-tab', 'config-tab', 'dashboard-tab', 'nexus-tab', 'builder-tab'];
   let currentIndex = 0;
   let isMobile = false;
 
@@ -4591,4 +4591,521 @@ function $(id) { return document.getElementById(id); }
       else refreshStats();  // always refresh stats strip on tab visit
     });
   }
+})();
+
+// ── Movement Builder ──────────────────────────────────────────────────────────
+(function () {
+  var DEFAULT_STEP = function () {
+    return {
+      movement: null,
+      left_height: 50, right_height: 50, left_leg: 50, right_leg: 50,
+      left_main: null, left_forearm: null, left_hand: null,
+      right_main: null, right_forearm: null, right_hand: null,
+      speed: 0.85, hold_time: 0.0
+    };
+  };
+
+  var steps = [DEFAULT_STEP()];
+  var savedSequences = {};
+  var movements = [];
+  var livePreview = false;
+  var armsPresent = false;
+  var sequencePlaying = false;
+  var confirmOverwrite = false;
+  var dragFromIndex = null;
+  var dragOverIndex = null;
+
+  function el(id) { return document.getElementById(id); }
+
+  function setFeedback(msg, isError) {
+    var fb = el('bldFeedback');
+    if (!fb) return;
+    fb.textContent = msg;
+    fb.style.color = isError ? 'var(--bs-danger)' : '';
+  }
+
+  // ── Init ──────────────────────────────────────────────────────────────────
+
+  function init() {
+    fetch('/get_arms_status').then(function (r) { return r.json(); }).then(function (d) {
+      armsPresent = !!d.arms_present;
+      renderSteps();
+    }).catch(function () { renderSteps(); });
+
+    fetch('/get_movements').then(function (r) { return r.json(); }).then(function (d) {
+      movements = (d.movements || [])
+        .filter(function (m) { return m.id !== 'reset_positions'; })
+        .map(function (m) { return m.id; });
+      var sel = el('bldMovementSelect');
+      if (sel) {
+        sel.innerHTML = '';
+        movements.forEach(function (id) {
+          var opt = document.createElement('option');
+          opt.value = id;
+          opt.textContent = id;
+          sel.appendChild(opt);
+        });
+      }
+    }).catch(function () {});
+
+    loadSavedSequences();
+
+    var liveBtn = el('bldLiveToggle');
+    if (liveBtn) {
+      liveBtn.addEventListener('click', function () {
+        livePreview = !livePreview;
+        liveBtn.textContent = livePreview ? 'Live: ON' : 'Live: OFF';
+        liveBtn.classList.toggle('active', livePreview);
+      });
+    }
+    if (el('bldAddPosition')) el('bldAddPosition').addEventListener('click', addPositionStep);
+    if (el('bldAddMovement')) el('bldAddMovement').addEventListener('click', addMovementStep);
+    if (el('bldImportMovement')) el('bldImportMovement').addEventListener('click', importMovement);
+    if (el('bldPlay')) el('bldPlay').addEventListener('click', playSequence);
+    if (el('bldNeutral')) el('bldNeutral').addEventListener('click', resetToNeutral);
+    if (el('bldSave')) el('bldSave').addEventListener('click', saveSequence);
+    if (el('bldClear')) el('bldClear').addEventListener('click', clearSteps);
+  }
+
+  // ── Step management ───────────────────────────────────────────────────────
+
+  function addPositionStep() {
+    steps.push(DEFAULT_STEP());
+    renderSteps();
+  }
+
+  function addMovementStep() {
+    var sel = el('bldMovementSelect');
+    var name = sel ? sel.value : '';
+    if (!name) return;
+    steps.push({ movement: name, hold_time: 0.0 });
+    renderSteps();
+  }
+
+  function deleteStep(i) {
+    steps.splice(i, 1);
+    renderSteps();
+  }
+
+  function clearSteps() {
+    steps = [DEFAULT_STEP()];
+    var nameEl = el('bldSeqName');
+    if (nameEl) nameEl.value = '';
+    confirmOverwrite = false;
+    el('bldOverwriteConfirm') && (el('bldOverwriteConfirm').style.display = 'none');
+    setFeedback('');
+    renderSteps();
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  function renderSteps() {
+    var container = el('bldStepList');
+    if (!container) return;
+    container.innerHTML = '';
+
+    steps.forEach(function (step, i) {
+      var wrapper = document.createElement('div');
+      wrapper.className = 'bld-step';
+      wrapper.draggable = true;
+      wrapper.dataset.index = i;
+
+      wrapper.addEventListener('dragstart', function (e) {
+        if (dragFromIndex === null) { e.preventDefault(); return; }
+        e.dataTransfer.effectAllowed = 'move';
+      });
+      wrapper.addEventListener('dragend', function () { dragFromIndex = null; renderSteps(); });
+      wrapper.addEventListener('dragover', function (e) { e.preventDefault(); dragOverIndex = i; });
+      wrapper.addEventListener('drop', function () {
+        if (dragFromIndex !== null && dragFromIndex !== i) {
+          var moved = steps.splice(dragFromIndex, 1)[0];
+          steps.splice(i, 0, moved);
+          renderSteps();
+        }
+        dragFromIndex = null;
+      });
+
+      var label = document.createElement('div');
+      label.className = 'bld-step-label';
+      label.textContent = 'Step ' + (i + 1);
+      wrapper.appendChild(label);
+
+      if (step.movement) {
+        wrapper.appendChild(buildMovementRow(step, i));
+      } else {
+        wrapper.appendChild(buildPositionRow(step, i));
+      }
+
+      container.appendChild(wrapper);
+    });
+  }
+
+  function buildMovementRow(step, i) {
+    var row = document.createElement('div');
+    row.className = 'bld-row bld-movement-row';
+
+    var grip = document.createElement('span');
+    grip.className = 'bld-grip';
+    grip.textContent = '⠿';
+    grip.addEventListener('pointerdown', function () { dragFromIndex = i; });
+    row.appendChild(grip);
+
+    var icon = document.createElement('span');
+    icon.className = 'bld-zap';
+    icon.textContent = '⚡';
+    row.appendChild(icon);
+
+    var name = document.createElement('span');
+    name.className = 'bld-movement-name';
+    name.textContent = step.movement;
+    row.appendChild(name);
+
+    var del = document.createElement('button');
+    del.className = 'bld-del';
+    del.textContent = '×';
+    del.addEventListener('click', function () { deleteStep(i); });
+    row.appendChild(del);
+
+    return row;
+  }
+
+  function buildPositionRow(step, i) {
+    var row = document.createElement('div');
+    row.className = 'bld-row bld-position-row';
+
+    var grip = document.createElement('span');
+    grip.className = 'bld-grip';
+    grip.textContent = '⠿';
+    grip.addEventListener('pointerdown', function () { dragFromIndex = i; });
+    row.appendChild(grip);
+
+    var sliders = document.createElement('div');
+    sliders.className = 'bld-sliders';
+
+    var legFields = [
+      { field: 'left_height', label: 'LH', min: 1, max: 100, step: 1 },
+      { field: 'right_height', label: 'RH', min: 1, max: 100, step: 1 },
+      { field: 'left_leg', label: 'LL', min: 1, max: 100, step: 1 },
+      { field: 'right_leg', label: 'RL', min: 1, max: 100, step: 1 },
+      { field: 'speed', label: 'Spd', min: 0.1, max: 1.0, step: 0.05 },
+      { field: 'hold_time', label: 'Hold', min: 0, max: 5, step: 0.1 }
+    ];
+
+    legFields.forEach(function (cfg) {
+      sliders.appendChild(buildSlider(step, i, cfg, true));
+    });
+
+    if (armsPresent) {
+      var armToggle = document.createElement('button');
+      armToggle.className = 'bld-arm-toggle';
+      armToggle.textContent = 'Arms ▾';
+      var armSection = document.createElement('div');
+      armSection.className = 'bld-arm-section';
+      armSection.style.display = 'none';
+      armToggle.addEventListener('click', function () {
+        var open = armSection.style.display !== 'none';
+        armSection.style.display = open ? 'none' : '';
+        armToggle.textContent = open ? 'Arms ▾' : 'Arms ▴';
+      });
+
+      var armFields = [
+        { field: 'left_main', label: 'LM', min: 1, max: 100, step: 1 },
+        { field: 'left_forearm', label: 'LF', min: 1, max: 100, step: 1 },
+        { field: 'left_hand', label: 'LH2', min: 1, max: 100, step: 1 },
+        { field: 'right_main', label: 'RM', min: 1, max: 100, step: 1 },
+        { field: 'right_forearm', label: 'RF', min: 1, max: 100, step: 1 },
+        { field: 'right_hand', label: 'RH2', min: 1, max: 100, step: 1 }
+      ];
+      armFields.forEach(function (cfg) {
+        armSection.appendChild(buildSlider(step, i, cfg, false));
+      });
+
+      sliders.appendChild(armToggle);
+      sliders.appendChild(armSection);
+    }
+
+    row.appendChild(sliders);
+
+    var del = document.createElement('button');
+    del.className = 'bld-del';
+    del.textContent = '×';
+    del.addEventListener('click', function () { deleteStep(i); });
+    row.appendChild(del);
+
+    return row;
+  }
+
+  function buildSlider(step, stepIndex, cfg, liveEnabled) {
+    var wrap = document.createElement('div');
+    wrap.className = 'bld-slider-wrap';
+
+    var header = document.createElement('div');
+    header.className = 'bld-slider-header';
+
+    var labelEl = document.createElement('span');
+    labelEl.textContent = cfg.label;
+
+    var valEl = document.createElement('span');
+    valEl.className = 'bld-slider-val';
+    var rawVal = step[cfg.field];
+    if (rawVal === null || rawVal === undefined) rawVal = 1;
+    valEl.textContent = cfg.field === 'speed' ? rawVal.toFixed(2)
+      : cfg.field === 'hold_time' ? rawVal.toFixed(1)
+      : rawVal;
+
+    header.appendChild(labelEl);
+    header.appendChild(valEl);
+
+    var input = document.createElement('input');
+    input.type = 'range';
+    input.min = cfg.min;
+    input.max = cfg.max;
+    input.step = cfg.step;
+    input.value = rawVal;
+    input.className = 'bld-slider';
+
+    input.addEventListener('input', function () {
+      var v = cfg.field === 'speed' || cfg.field === 'hold_time'
+        ? parseFloat(this.value)
+        : parseInt(this.value);
+      steps[stepIndex][cfg.field] = v;
+      valEl.textContent = cfg.field === 'speed' ? v.toFixed(2)
+        : cfg.field === 'hold_time' ? v.toFixed(1)
+        : v;
+    });
+
+    if (liveEnabled && cfg.field !== 'hold_time') {
+      var sendLive = function () {
+        if (!livePreview) return;
+        var s = steps[stepIndex];
+        if (s.movement) return;
+        fetch('/move_legs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            left_height: s.left_height, right_height: s.right_height,
+            left_leg: s.left_leg, right_leg: s.right_leg, speed: s.speed
+          })
+        }).catch(function () {});
+      };
+      input.addEventListener('mouseup', sendLive);
+      input.addEventListener('touchend', sendLive);
+    }
+
+    wrap.appendChild(header);
+    wrap.appendChild(input);
+    return wrap;
+  }
+
+  // ── Playback ──────────────────────────────────────────────────────────────
+
+  function playSequence() {
+    if (sequencePlaying) return;
+    sequencePlaying = true;
+    setFeedback('Playing...');
+    var playBtn = el('bldPlay');
+    if (playBtn) playBtn.disabled = true;
+
+    fetch('/play_sequence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ steps: steps })
+    }).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, d: d }; });
+    }).then(function (res) {
+      setFeedback(res.ok ? 'Sequence complete.' : ('Error: ' + (res.d.error || 'failed')), !res.ok);
+    }).catch(function (err) {
+      setFeedback('Error: ' + err.message, true);
+    }).finally(function () {
+      sequencePlaying = false;
+      if (playBtn) playBtn.disabled = false;
+    });
+  }
+
+  function resetToNeutral() {
+    fetch('/move_legs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ left_height: 50, right_height: 50, left_leg: 50, right_leg: 50, speed: 0.8 })
+    }).catch(function () {});
+  }
+
+  // ── Save / Load ───────────────────────────────────────────────────────────
+
+  function loadSavedSequences() {
+    fetch('/get_saved_sequences').then(function (r) { return r.json(); }).then(function (d) {
+      savedSequences = d;
+      renderSaved();
+    }).catch(function () {});
+  }
+
+  function saveSequence() {
+    var nameEl = el('bldSeqName');
+    var name = nameEl ? nameEl.value.trim() : '';
+    if (!name) { setFeedback('Enter a name before saving.', true); return; }
+
+    if (savedSequences[name] && !confirmOverwrite) {
+      confirmOverwrite = true;
+      var conf = el('bldOverwriteConfirm');
+      if (conf) {
+        conf.style.display = '';
+        var confMsg = conf.querySelector('.bld-confirm-msg');
+        if (confMsg) confMsg.textContent = '"' + name + '" already exists. Replace?';
+      }
+      return;
+    }
+    confirmOverwrite = false;
+    var conf2 = el('bldOverwriteConfirm');
+    if (conf2) conf2.style.display = 'none';
+
+    var typeEl = el('bldSeqType');
+    var quickEl = el('bldSeqQuick');
+    var seqType = typeEl ? typeEl.value : 'movement';
+    var quick = quickEl ? quickEl.checked : false;
+
+    fetch('/save_sequence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, steps: steps, type: seqType, quick: quick })
+    }).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, d: d }; });
+    }).then(function (res) {
+      if (res.ok) {
+        setFeedback('Saved "' + name + '"');
+        if (nameEl) nameEl.value = '';
+        loadSavedSequences();
+      } else {
+        setFeedback('Save failed.', true);
+      }
+    }).catch(function (err) {
+      setFeedback('Error: ' + err.message, true);
+    });
+  }
+
+  function playSaved(name) {
+    if (sequencePlaying) return;
+    sequencePlaying = true;
+    setFeedback('Playing "' + name + '"...');
+    fetch('/play_saved_sequence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name })
+    }).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, d: d }; });
+    }).then(function (res) {
+      setFeedback(res.ok ? '"' + name + '" complete.' : ('Error: ' + (res.d.error || 'failed')), !res.ok);
+    }).catch(function (err) {
+      setFeedback('Error: ' + err.message, true);
+    }).finally(function () { sequencePlaying = false; });
+  }
+
+  function loadIntoEditor(name) {
+    var entry = savedSequences[name];
+    if (!entry) return;
+    var raw = Array.isArray(entry) ? entry : (entry.steps || []);
+    steps = raw.map(function (s) {
+      if (s.movement) return { movement: s.movement, hold_time: s.hold_time || 0 };
+      return {
+        movement: null,
+        left_height: s.left_height || 50, right_height: s.right_height || 50,
+        left_leg: s.left_leg || 50, right_leg: s.right_leg || 50,
+        left_main: s.left_main || null, left_forearm: s.left_forearm || null,
+        left_hand: s.left_hand || null, right_main: s.right_main || null,
+        right_forearm: s.right_forearm || null, right_hand: s.right_hand || null,
+        speed: s.speed || 0.85, hold_time: s.hold_time || 0
+      };
+    });
+    var nameEl = el('bldSeqName');
+    if (nameEl) nameEl.value = name;
+    var typeEl = el('bldSeqType');
+    if (typeEl && entry.type) typeEl.value = entry.type;
+    setFeedback('Loaded "' + name + '"');
+    renderSteps();
+  }
+
+  function deleteSaved(name) {
+    fetch('/delete_saved_sequence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name })
+    }).then(function () { loadSavedSequences(); }).catch(function () {});
+  }
+
+  function importMovement() {
+    var sel = el('bldMovementSelect');
+    var name = sel ? sel.value : '';
+    if (!name) return;
+    setFeedback('Importing "' + name + '"...');
+    fetch('/get_movement_steps/' + encodeURIComponent(name))
+      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
+      .then(function (res) {
+        if (res.ok) {
+          steps = res.d.steps;
+          var nameEl = el('bldSeqName');
+          if (nameEl) nameEl.value = '';
+          setFeedback('Imported "' + name + '" — edit then save under a new name');
+          renderSteps();
+        } else {
+          setFeedback('Import failed: ' + (res.d.error || 'unknown'), true);
+        }
+      }).catch(function (err) {
+        setFeedback('Error: ' + err.message, true);
+      });
+  }
+
+  function renderSaved() {
+    var container = el('bldSavedList');
+    if (!container) return;
+    var names = Object.keys(savedSequences);
+    if (names.length === 0) {
+      container.innerHTML = '<span class="bld-empty">No saved sequences.</span>';
+      return;
+    }
+    container.innerHTML = '';
+    names.forEach(function (name) {
+      var chip = document.createElement('div');
+      chip.className = 'bld-chip';
+
+      var playBtn = document.createElement('button');
+      playBtn.className = 'bld-chip-play';
+      playBtn.textContent = name;
+      playBtn.title = 'Play';
+      playBtn.addEventListener('click', function () { playSaved(name); });
+
+      var editBtn = document.createElement('button');
+      editBtn.className = 'bld-chip-edit';
+      editBtn.textContent = '✎';
+      editBtn.title = 'Load into editor';
+      editBtn.addEventListener('click', function () { loadIntoEditor(name); });
+
+      var delBtn = document.createElement('button');
+      delBtn.className = 'bld-chip-del';
+      delBtn.textContent = '×';
+      delBtn.title = 'Delete';
+      delBtn.addEventListener('click', function () { deleteSaved(name); });
+
+      chip.appendChild(playBtn);
+      chip.appendChild(editBtn);
+      chip.appendChild(delBtn);
+      container.appendChild(chip);
+    });
+  }
+
+  // ── Overwrite confirm cancel ───────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', function () {
+    var cancelBtn = el('bldOverwriteCancel');
+    if (cancelBtn) cancelBtn.addEventListener('click', function () {
+      confirmOverwrite = false;
+      var conf = el('bldOverwriteConfirm');
+      if (conf) conf.style.display = 'none';
+    });
+    var replaceBtn = el('bldOverwriteReplace');
+    if (replaceBtn) replaceBtn.addEventListener('click', function () {
+      confirmOverwrite = true;
+      saveSequence();
+    });
+  });
+
+  // ── Boot ──────────────────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', init);
 })();

--- a/src/www/templates/index.html
+++ b/src/www/templates/index.html
@@ -40,6 +40,7 @@
       <button class="custom-tab"        id="config-tab"   data-bs-toggle="tab" data-bs-target="#config"   role="tab" aria-label="Config"><i class="bi bi-gear-fill"></i></button>
       <button class="custom-tab"        id="dashboard-tab" data-bs-toggle="tab" data-bs-target="#dashboard" role="tab" aria-label="Dashboard"><i class="bi bi-graph-up"></i></button>
       <button class="custom-tab"        id="nexus-tab"    data-bs-toggle="tab" data-bs-target="#nexus"    role="tab" aria-label="SYS"><i class="bi bi-cpu"></i></button>
+      <button class="custom-tab"        id="builder-tab"  data-bs-toggle="tab" data-bs-target="#builder"  role="tab" aria-label="Builder"><i class="bi bi-layers-fill"></i></button>
     </div>
     <div class="tab-bar-right">
       <div class="connection-indicator" id="connIndicator">
@@ -63,6 +64,7 @@
       {% include 'tabs/config.html' %}
       {% include 'tabs/dashboard.html' %}
       {% include 'tabs/sys.html' %}
+      {% include 'tabs/builder.html' %}
     </div>
   </div>
 
@@ -77,6 +79,7 @@
       <button class="mobile-nav-btn" data-tab-index="5" aria-label="Config"><i class="bi bi-gear-fill"></i><span>Config</span></button>
       <button class="mobile-nav-btn" data-tab-index="6" aria-label="Dashboard"><i class="bi bi-graph-up"></i><span>Dash</span></button>
       <button class="mobile-nav-btn" data-tab-index="7" aria-label="SYS"><i class="bi bi-cpu"></i><span>SYS</span></button>
+      <button class="mobile-nav-btn" data-tab-index="8" aria-label="Builder"><i class="bi bi-layers-fill"></i><span>Build</span></button>
     </div>
   </nav>
 
@@ -95,7 +98,7 @@
   </script>
 
   <script src="{{ url_for('static', filename='js/d3.v7.min.js') }}?v=7.4"></script>
-  <script src="{{ url_for('static', filename='js/main.js') }}?v=7.4"></script>
+  <script src="{{ url_for('static', filename='js/main.js') }}?v=7.5"></script>
   <script src="{{ url_for('static', filename='js/particles.js') }}?v=7.4"></script>
 </body>
 </html>

--- a/src/www/templates/tabs/builder.html
+++ b/src/www/templates/tabs/builder.html
@@ -1,0 +1,331 @@
+<div class="tab-pane fade" id="builder" role="tabpanel">
+  <div class="builder-wrap">
+
+    <div class="builder-header">
+      <span class="section-label">MOVEMENT BUILDER</span>
+      <button class="bld-live-btn" id="bldLiveToggle">Live: OFF</button>
+    </div>
+
+    <!-- Channel legend -->
+    <div class="bld-legend">
+      <span><b>LH</b> left height</span>
+      <span><b>RH</b> right height</span>
+      <span><b>LL</b> left leg fwd/back</span>
+      <span><b>RL</b> right leg fwd/back</span>
+    </div>
+
+    <!-- Step list -->
+    <div class="bld-step-list" id="bldStepList"></div>
+
+    <!-- Add steps -->
+    <div class="bld-section">
+      <div class="section-label">ADD STEP</div>
+      <button class="hud-btn hud-btn-secondary" id="bldAddPosition">+ Position Step</button>
+      <div class="bld-movement-add">
+        <select id="bldMovementSelect" class="hud-select bld-movement-sel">
+          <option value="">Loading…</option>
+        </select>
+        <button class="hud-btn hud-btn-secondary" id="bldAddMovement" title="Append as named movement step">⚡</button>
+        <button class="hud-btn hud-btn-secondary" id="bldImportMovement" title="Import as editable position steps">↓</button>
+      </div>
+      <div class="bld-hint">
+        <span>⚡ named step</span>
+        <span>↓ import as editable steps</span>
+      </div>
+    </div>
+
+    <!-- Playback -->
+    <div class="bld-section">
+      <div class="section-label">PLAYBACK</div>
+      <div class="bld-row-actions">
+        <button class="hud-btn hud-btn-primary" id="bldPlay">▶ Play</button>
+        <button class="hud-btn hud-btn-secondary" id="bldNeutral">↺ Neutral</button>
+      </div>
+    </div>
+
+    <!-- Save -->
+    <div class="bld-section">
+      <div class="section-label">SAVE</div>
+      <div class="bld-save-row">
+        <input type="text" id="bldSeqName" class="hud-input bld-name-input" placeholder="Sequence name">
+        <button class="hud-btn hud-btn-primary" id="bldSave">Save</button>
+        <button class="hud-btn hud-btn-secondary" id="bldClear" title="Clear all steps">🗑</button>
+      </div>
+      <div class="bld-overwrite-confirm" id="bldOverwriteConfirm" style="display:none">
+        <span class="bld-confirm-msg"></span>
+        <button class="hud-btn hud-btn-danger" id="bldOverwriteReplace">Replace</button>
+        <button class="hud-btn" id="bldOverwriteCancel">Cancel</button>
+      </div>
+    </div>
+
+    <!-- Feedback -->
+    <div class="bld-feedback" id="bldFeedback"></div>
+
+    <!-- Saved sequences -->
+    <div class="bld-section">
+      <div class="section-label">SAVED</div>
+      <div class="bld-saved-list" id="bldSavedList">
+        <span class="bld-empty">No saved sequences.</span>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<style>
+#builder {
+  overflow-y: auto;
+}
+.builder-wrap {
+  padding: 1rem;
+  max-width: 700px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: calc(var(--mobile-nav-h, 60px) + 1rem);
+}
+.builder-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.bld-live-btn {
+  background: transparent;
+  border: 1px solid var(--text-dim);
+  color: var(--text-dim);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.bld-live-btn.active {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.bld-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.72rem;
+  opacity: 0.6;
+}
+.bld-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.bld-step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 60px;
+}
+.bld-step {
+  cursor: default;
+}
+.bld-step-label {
+  font-size: 0.7rem;
+  opacity: 0.5;
+  margin-bottom: 2px;
+}
+.bld-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 6px;
+}
+.bld-movement-row {
+  align-items: center;
+}
+.bld-grip {
+  cursor: grab;
+  opacity: 0.4;
+  font-size: 1rem;
+  line-height: 1;
+  flex-shrink: 0;
+  user-select: none;
+}
+.bld-zap {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+.bld-movement-name {
+  flex: 1;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+.bld-del {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+.bld-del:hover { color: var(--red); }
+.bld-sliders {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+}
+.bld-slider-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 70px;
+}
+.bld-slider-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+.bld-slider-val {
+  font-family: monospace;
+}
+.bld-slider {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+}
+.bld-arm-toggle {
+  background: transparent;
+  border: 1px solid var(--text-dim);
+  color: var(--text-dim);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  margin-top: 4px;
+}
+.bld-arm-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  margin-top: 4px;
+}
+.bld-movement-add {
+  display: flex;
+  gap: 6px;
+}
+.bld-movement-sel {
+  flex: 1;
+}
+.bld-hint {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  opacity: 0.5;
+}
+.bld-row-actions {
+  display: flex;
+  gap: 8px;
+}
+.bld-save-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.bld-name-input {
+  flex: 1;
+  min-width: 120px;
+}
+.bld-type-sel {
+  width: auto;
+}
+.bld-quick-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.bld-overwrite-confirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: rgba(255,255,255,0.05);
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+.bld-confirm-msg {
+  flex: 1;
+  opacity: 0.8;
+}
+.bld-feedback {
+  font-size: 0.85rem;
+  min-height: 1.2em;
+  opacity: 0.8;
+}
+.bld-saved-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.bld-empty {
+  font-size: 0.8rem;
+  opacity: 0.4;
+}
+.bld-chip {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: rgba(255,255,255,0.07);
+  border-radius: 6px;
+  padding: 2px 6px;
+}
+.bld-chip-play {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.bld-chip-play:hover { color: var(--cyan); }
+.bld-chip-edit,
+.bld-chip-del {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.bld-chip-edit:hover { color: var(--cyan); }
+.bld-chip-del:hover { color: var(--red); }
+.hud-input {
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.15);
+  color: inherit;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.85rem;
+}
+.hud-btn-secondary {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.12);
+  color: var(--text-dim);
+}
+.hud-btn-secondary:hover {
+  border-color: rgba(var(--accent-rgb), 0.35);
+  color: var(--cyan);
+}
+.hud-btn-danger {
+  background: rgba(255,68,68,0.12);
+  border: 1px solid rgba(255,68,68,0.4);
+  color: var(--red);
+}
+</style>


### PR DESCRIPTION
## Summary

- Add Movement Builder tab to the dashboard UI
- Add 7 new Flask routes for sequence management (play, save, load, delete, import steps)
- Remove ~160 lines of dead animation code from module_eyes.py (10 unused anim_* methods)

## Movement Builder

New tab accessible from desktop nav and mobile bottom nav (Bootstrap `bi-layers-fill` icon).

**Features:**
- Add position steps with sliders for all 4 leg servos (+ 6 arm servos if `ARMS_PRESENT`)
- Add named movement steps (references an existing movement by name)
- Import any existing movement as editable position steps
- Drag-to-reorder steps
- Live preview toggle (moves servos in real time as sliders change)
- Play full sequence, reset to neutral
- Save sequences to `custom_sequences.json` with a name
- Load, play, edit, and delete saved sequences from the dashboard
- Saved sequences automatically appear in the Motion tab dropdown and are callable via LLM/voice

**New routes in `module_chatui.py`:**
- `GET /get_arms_status`
- `POST /play_sequence`
- `POST /save_sequence`
- `GET /get_saved_sequences`
- `POST /delete_saved_sequence`
- `POST /play_saved_sequence`
- `GET /get_movement_steps/<name>`

**New file:** `src/www/templates/tabs/builder.html`

## Eye Animation Cleanup

`module_eyes.py` contained 10 `anim_*` methods and a `_update_animations()` dispatch loop (~160 lines) that were never called from any other module. Removed to reduce dead code. The random blinking system is unaffected.

Removed: `is_animating`, `anim_wink`, `anim_double_take`, `anim_eye_roll`, `anim_excited`, `anim_sleepy`, `anim_thinking`, `anim_blink_fast`, `anim_squint_suspicious`, `anim_laugh`, `anim_confused`, `_update_animations`